### PR TITLE
DOC Improve instructions for environement setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,20 +15,29 @@ and put them to into the data folder.
 ### Install
 
 To run a submission and the notebook you will need the dependencies listed
-in `requirements.txt`. You can install the dependencies with the
-following command-line:
+in `requirements.txt`.
 
+It is recommended to create a new environment for this project and
+to install those dependencies inside this new environment.
+
+You can create a new conda environement named `bikes-ramp` using:
 ```bash
-pip install -U -r requirements.txt
+conda create --name bikes-ramp python=3.9
 ```
 
-It is recommended to create a new virtual environment for this project. For instance, with conda,
-```bash
-conda create -n bikes-ramp python=3.9
+and then use this new environment install the dependencies in it using pip:
+
+```
 conda activate bikes-ramp
 pip install -r requirements.txt
 ```
 
+Later on when you work on your project, you need to use the `bikes-ramp`
+environement in any terminal session. This is once again done with:
+
+```
+conda activate bikes-ramp
+```
 
 ### Challenge description
 


### PR DESCRIPTION
I think having this single set of instructions is less confusing for new-comers and would prevent any base environement corruption. What do you think?

cc @rth 